### PR TITLE
Add bug workaround notice

### DIFF
--- a/ShadowFinderColab.ipynb
+++ b/ShadowFinderColab.ipynb
@@ -14,7 +14,9 @@
     "\n",
     "Using an object's height and the length of its shadow (or the angle to the sun) with the date and the time, this code estimates the possible locations of that shadow.\n",
     "\n",
-    "> <font color='#ffc107'>Important:</font> The shadow length must be measured at right angles to the object 📐 This means that you might have to correct for the perspective of an image before using this tool."
+    "> <font color='#ffc107'>Important:</font> The shadow length must be measured at right angles to the object 📐 This means that you might have to correct for the perspective of an image before using this tool.\n",
+    "\n",
+    "> <font color='#ab0107'>Bug Workaround:</font> At the moment there is a bug with Shadow Finder which results in an error. You can still use the tool in Google Colab by running the tool, getting the error, then restarting the session. Do this by navigating to the 'Runtime' menu at the top of the window, then click 'Restart session'. When you run the tool a second time it should work."
    ]
   },
   {


### PR DESCRIPTION
Currently the bug mentioned in #27 is not fixable while we wait for an update to basemap. This adds a notice to the notebook to help users apply the temporary workaround before we fix the tool in the future.