### PR TITLE
pypi publish workflow fix

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -14,4 +14,4 @@ jobs:
         uses: JRubics/poetry-publish@v1.17
         with:
           pypi_token: ${{ secrets.PYPI_TOKEN }}
-          python_version: 3.10
+          python_version: "3.10"


### PR DESCRIPTION
Adds quotes around Python version to avoid building against Python 3.1 rather than 3.10