### PR TITLE
bug(time_format): Force mutability on return from suncalc pandas data

### DIFF
--- a/src/shadowfinder/shadowfinder.py
+++ b/src/shadowfinder/shadowfinder.py
@@ -191,7 +191,7 @@ class ShadowFinder:
 
         pos_obj = get_position(valid_datetimes, valid_lons, valid_lats)
 
-        valid_sun_altitudes = pos_obj["altitude"]  # in radians
+        valid_sun_altitudes = np.array(pos_obj["altitude"])  # in radians
 
         # If object height and shadow length are set the sun altitudes are used
         #  to calculate the shadow lengths across the world and then compared to

--- a/tests/test_shadowfinder.py
+++ b/tests/test_shadowfinder.py
@@ -15,3 +15,25 @@ def test_creation_with_valid_arguments_should_pass():
     ShadowFinder(
         object_height=object_height, shadow_length=shadow_length, date_time=date_time
     )
+
+
+def _gen_simple_finder_local_time():
+    object_height = 6
+    shadow_length = 3.2
+    date_time = datetime.now()
+
+    return ShadowFinder(
+        object_height=object_height,
+        shadow_length=shadow_length,
+        date_time=date_time,
+        time_format="local",
+    )
+
+
+def test_creation_with_valid_arguments_local_time_format_should_pass():
+    _gen_simple_finder_local_time()
+
+
+def test_find_shadows_with_local_time_format():
+    finder = _gen_simple_finder_local_time()
+    finder.find_shadows()


### PR DESCRIPTION
Addressing #31 -- 

The suncalc library returns a dictionary with pandas Series/Index objects depending on the input. When passed a pandas DatetimeIndex, the returned altitude values retain that Index type, which is immutable. This fix follows the pattern in the repo to allow mutation of altitudes. 