### PR TITLE
fix(cli): use correct default grid filename in find_sun

### DIFF
--- a/src/shadowfinder/cli.py
+++ b/src/shadowfinder/cli.py
@@ -68,7 +68,7 @@ class ShadowFinderCli:
         date: str,
         time: str,
         time_format: str = "utc",
-        grid: str = "timezene_grid.json",
+        grid: str = "timezone_grid.json",
     ) -> None:
         """
         Locate a shadow based on the solar altitude angle and the date and time.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,29 @@
+"""
+The tests in this file test the CLI wrapper (shadowfinder.cli).
+"""
+
+import inspect
+
+import pytest
+
+from shadowfinder.cli import ShadowFinderCli
+
+# The timezone grid file that ships with the package and is produced by
+# `generate_timezone_grid`. Commands that read a cached grid must default to
+# this exact name, otherwise the lookup misses and the grid is regenerated
+# from scratch on every run (see quick_find's FileNotFoundError fallback).
+EXPECTED_GRID = "timezone_grid.json"
+
+
+@pytest.mark.parametrize("command", ["find", "find_sun", "generate_timezone_grid"])
+def test_cli_grid_default_is_consistent(command):
+    """Every CLI command that takes a `grid` argument must default to the same
+    packaged grid filename. A mismatched default silently defeats grid caching."""
+    # GIVEN
+    signature = inspect.signature(getattr(ShadowFinderCli, command))
+
+    # WHEN
+    grid_param = signature.parameters["grid"]
+
+    # THEN
+    assert grid_param.default == EXPECTED_GRID


### PR DESCRIPTION
## What

The `find_sun` command defaults its `--grid` argument to `timezene_grid.json` (misspelled), while `find` and `generate_timezone_grid` both use `timezone_grid.json`.

## Why it matters

Because `timezene_grid.json` never exists, `quick_find` always hits its `FileNotFoundError` fallback and regenerates the entire global timezone grid on every `find_sun` run. This silently defeats the CLI grid caching added in #21 — `find` benefits from the cached grid, but `find_sun` never does.

## Changes

- One-character fix to the `find_sun` default in `cli.py` so all three commands share the same grid filename.
- Add `tests/test_cli.py` covering the `grid` defaults across `find`, `find_sun`, and `generate_timezone_grid`. The CLI previously had no direct tests; the new test fails on the old default and passes on the fix.

Verified locally: full test suite passes (7 passed) and `black` reports no changes.