### PR TITLE
feat: propagate measurement and time uncertainty into the result band (closes #3, #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ finder.set_details(
     shadow_length=shadow_length, # shadow length in arbitrary units
     time_format=time_type, # string, either 'local' or 'utc'
     sun_altitude_angle=sun_altitude_angle, # altitude angle of the sun, in degrees above the horizon
+    # Optional uncertainties. When any are given, the possible-location band is
+    # widened to the region consistent with the observation within them:
+    object_height_uncertainty=object_height_uncertainty, # same units as object_height
+    shadow_length_uncertainty=shadow_length_uncertainty, # same units as shadow_length
+    sun_altitude_angle_uncertainty=sun_altitude_angle_uncertainty, # degrees
+    time_uncertainty=time_uncertainty, # seconds (or a datetime.timedelta)
 )
 
 # Run the finder
@@ -73,6 +79,16 @@ You can also use the angle to the sun directly (above the horizon, in degrees):
 shadowfinder find_sun 50 2024-02-29 13:59:59 --time_format=utc
 ```
 Where the arguments are `SUN_ALTITUDE_ANGLE`, `DATE`, and `TIME` respectively.
+
+If the measurements or the time are only known approximately, pass their
+uncertainties to widen the band to the region consistent with the observation:
+
+```shell
+shadowfinder find 10 5 2024-02-29 13:59:59 --time_format=utc \
+  --object_height_uncertainty=0.5 --shadow_length_uncertainty=0.5 --time_uncertainty=1800
+```
+
+Where `--time_uncertainty` is in seconds (here +/- 30 minutes).
 
 More complete help information can be found by running:
 

--- a/src/shadowfinder/cli.py
+++ b/src/shadowfinder/cli.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 
 from shadowfinder import ShadowFinder
 
@@ -42,6 +43,9 @@ class ShadowFinderCli:
         time: str,
         time_format: str = "utc",
         grid: str = "timezone_grid.json",
+        object_height_uncertainty: Optional[float] = None,
+        shadow_length_uncertainty: Optional[float] = None,
+        time_uncertainty: Optional[float] = None,
     ) -> None:
         """
         Find the shadow length of an object given its height and the date and time.
@@ -49,6 +53,12 @@ class ShadowFinderCli:
         :param shadow_length: Length of the shadow in arbitrary units
         :param date: Date in the format YYYY-MM-DD
         :param time: UTC Time in the format HH:MM:SS
+        :param object_height_uncertainty: Optional 1-sigma uncertainty on the
+            object height, in the same units, used to widen the result band.
+        :param shadow_length_uncertainty: Optional 1-sigma uncertainty on the
+            shadow length, in the same units, used to widen the result band.
+        :param time_uncertainty: Optional 1-sigma uncertainty on the observation
+            time, in seconds, used to widen the result band.
         """
 
         try:
@@ -58,7 +68,13 @@ class ShadowFinderCli:
         _validate_args(object_height, shadow_length, date_time)
 
         shadow_finder = ShadowFinder(
-            object_height, shadow_length, date_time, time_format
+            object_height,
+            shadow_length,
+            date_time,
+            time_format,
+            object_height_uncertainty=object_height_uncertainty,
+            shadow_length_uncertainty=shadow_length_uncertainty,
+            time_uncertainty=time_uncertainty,
         )
         shadow_finder.quick_find(grid)
 
@@ -69,12 +85,18 @@ class ShadowFinderCli:
         time: str,
         time_format: str = "utc",
         grid: str = "timezene_grid.json",
+        sun_altitude_angle_uncertainty: Optional[float] = None,
+        time_uncertainty: Optional[float] = None,
     ) -> None:
         """
         Locate a shadow based on the solar altitude angle and the date and time.
         :param sun_altitude_angle: Sun altitude angle in degrees
         :param date: Date in the format YYYY-MM-DD
         :param time: UTC Time in the format HH:MM:SS
+        :param sun_altitude_angle_uncertainty: Optional 1-sigma uncertainty on
+            the sun altitude angle, in degrees, used to widen the result band.
+        :param time_uncertainty: Optional 1-sigma uncertainty on the observation
+            time, in seconds, used to widen the result band.
         """
 
         try:
@@ -87,6 +109,8 @@ class ShadowFinderCli:
             date_time=date_time,
             time_format=time_format,
             sun_altitude_angle=sun_altitude_angle,
+            sun_altitude_angle_uncertainty=sun_altitude_angle_uncertainty,
+            time_uncertainty=time_uncertainty,
         )
         shadow_finder.quick_find(grid)
 

--- a/src/shadowfinder/shadowfinder.py
+++ b/src/shadowfinder/shadowfinder.py
@@ -9,6 +9,7 @@ import cartopy.feature as cfeature
 from cartopy.io import DownloadWarning
 from timezonefinder import TimezoneFinder
 import json
+from datetime import timedelta
 from warnings import warn, filterwarnings
 from math import radians
 
@@ -21,14 +22,27 @@ class ShadowFinder:
         date_time=None,
         time_format="utc",
         sun_altitude_angle=None,
+        object_height_uncertainty=None,
+        shadow_length_uncertainty=None,
+        sun_altitude_angle_uncertainty=None,
+        time_uncertainty=None,
     ):
         self.set_details(
-            date_time, object_height, shadow_length, time_format, sun_altitude_angle
+            date_time,
+            object_height,
+            shadow_length,
+            time_format,
+            sun_altitude_angle,
+            object_height_uncertainty,
+            shadow_length_uncertainty,
+            sun_altitude_angle_uncertainty,
+            time_uncertainty,
         )
 
         self.lats = None
         self.lons = None
         self.location_likelihoods = None
+        self.location_uncertainty = None
 
         self.timezones = None
         self.tf = TimezoneFinder(in_memory=True)
@@ -48,6 +62,10 @@ class ShadowFinder:
         shadow_length=None,
         time_format=None,
         sun_altitude_angle=None,
+        object_height_uncertainty=None,
+        shadow_length_uncertainty=None,
+        sun_altitude_angle_uncertainty=None,
+        time_uncertainty=None,
     ):
 
         if date_time is not None and date_time.tzinfo is not None:
@@ -56,6 +74,14 @@ class ShadowFinder:
             )
             date_time = date_time.replace(tzinfo=None)
         self.date_time = date_time
+
+        # Optional measurement/time uncertainties. When any are set, find_shadows
+        # propagates them into a per-cell uncertainty band (self.location_sigmas)
+        # instead of using the fixed default band width.
+        self.object_height_uncertainty = object_height_uncertainty
+        self.shadow_length_uncertainty = shadow_length_uncertainty
+        self.sun_altitude_angle_uncertainty = sun_altitude_angle_uncertainty
+        self.time_uncertainty = time_uncertainty
 
         if time_format is not None:
             assert time_format in [
@@ -153,8 +179,55 @@ class ShadowFinder:
         self.lons, self.lats = np.meshgrid(lons, lats)
         self.timezones = np.array(data["timezones"])
 
+    def _relative_difference(self, sun_altitudes):
+        # Relative difference between the shadow implied by each cell's sun
+        # altitude and the observed shadow (0 at a perfect match). Cells where
+        # the sun is below the horizon are set to nan.
+        if self.object_height is not None and self.shadow_length is not None:
+            shadow_lengths = self.object_height / np.tan(sun_altitudes)
+            shadow_lengths[sun_altitudes <= 0] = np.nan
+            return (shadow_lengths - self.shadow_length) / self.shadow_length
+
+        elif self.sun_altitude_angle is not None:
+            differences = (sun_altitudes - radians(self.sun_altitude_angle)) / radians(
+                self.sun_altitude_angle
+            )
+            differences[sun_altitudes <= 0] = np.nan
+            return differences
+
+        else:
+            raise ValueError(
+                "Either object height and shadow length or sun altitude angle needs to be set."
+            )
+
+    def _reshape_to_grid(self, values, mask):
+        # Place the values computed for the valid cells back onto the full grid.
+        if mask is None:
+            grid = values
+        else:
+            grid = np.full(np.shape(mask), np.nan)
+            np.place(grid, mask, values)
+        return np.reshape(grid, np.shape(self.lons), order="A")
+
+    def _measurement_relative_variance(self):
+        # Combined relative variance from the measurement uncertainties, used as
+        # the (location-independent) width of the acceptance band.
+        variance = 0.0
+        if self.object_height is not None and self.shadow_length is not None:
+            if self.object_height_uncertainty:
+                variance += (self.object_height_uncertainty / self.object_height) ** 2
+            if self.shadow_length_uncertainty:
+                variance += (self.shadow_length_uncertainty / self.shadow_length) ** 2
+        elif self.sun_altitude_angle is not None:
+            if self.sun_altitude_angle_uncertainty:
+                # The radians conversion cancels in the ratio.
+                variance += (
+                    self.sun_altitude_angle_uncertainty / self.sun_altitude_angle
+                ) ** 2
+        return variance
+
     def find_shadows(self):
-        # Evaluate the sun's length at a grid of points on the Earth's surface
+        # Evaluate the sun's position at a grid of points on the Earth's surface
 
         if self.lats is None or self.lons is None or self.timezones is None:
             self.generate_timezone_grid()
@@ -163,6 +236,7 @@ class ShadowFinder:
             valid_datetimes = utc.localize(self.date_time)
             valid_lats = self.lats.flatten()
             valid_lons = self.lons.flatten()
+            mask = None
         elif self.time_format == "local":
             datetimes = np.array(
                 [
@@ -189,56 +263,63 @@ class ShadowFinder:
             # Convert the datetimes to pandas series of timestamps
             valid_datetimes = pd.to_datetime(valid_datetimes, unit="s", utc=True)
 
-        pos_obj = get_position(valid_datetimes, valid_lons, valid_lats)
-
-        valid_sun_altitudes = np.array(pos_obj["altitude"])  # in radians
-
-        # If object height and shadow length are set the sun altitudes are used
-        #  to calculate the shadow lengths across the world and then compared to
-        #  the expected shadow length.
-        if self.object_height is not None and self.shadow_length is not None:
-            # Calculate the shadow length
-            shadow_lengths = self.object_height / np.apply_along_axis(
-                np.tan, 0, valid_sun_altitudes
+        def relative_difference_at(offset_seconds=0):
+            # Relative-difference surface for the valid cells at date_time shifted
+            # by offset_seconds (used to sweep the time-uncertainty band).
+            datetimes = valid_datetimes
+            if offset_seconds:
+                datetimes = valid_datetimes + timedelta(seconds=offset_seconds)
+            sun_altitudes = np.array(
+                get_position(datetimes, valid_lons, valid_lats)["altitude"]
             )
+            return self._relative_difference(sun_altitudes)
 
-            # Replace points where the sun is below the horizon with nan
-            shadow_lengths[valid_sun_altitudes <= 0] = np.nan
+        location_likelihoods = relative_difference_at()
 
-            # Show the relative difference between the calculated shadow length and the observed shadow length
-            location_likelihoods = (
-                shadow_lengths - self.shadow_length
-            ) / self.shadow_length
+        # Propagate the measurement and/or time uncertainties into a per-cell
+        # "consistency" surface: the distance from a perfect match (0) to the
+        # range of relative differences the observation could plausibly take
+        # given the uncertainties. A value of 0 means the cell is consistent
+        # with the observation. Stays None (unchanged output) when no
+        # uncertainty was supplied.
+        location_uncertainty = None
+        measurement_sigma = np.sqrt(self._measurement_relative_variance())
 
-        # If the sun altitude angle is set then this value is directly compared
-        #  to the sun altitudes across the world.
-        elif self.sun_altitude_angle is not None:
-            # Show relative difference between sun altitudes
-            location_likelihoods = (
-                np.array(valid_sun_altitudes) - radians(self.sun_altitude_angle)
-            ) / radians(self.sun_altitude_angle)
-
-            # Replace points where the sun is below the horizon
-            location_likelihoods[valid_sun_altitudes <= 0] = np.nan
-
+        if self.time_uncertainty:
+            seconds = (
+                self.time_uncertainty.total_seconds()
+                if isinstance(self.time_uncertainty, timedelta)
+                else float(self.time_uncertainty)
+            )
+            # Sweep the observation time by +/- its uncertainty. The relative
+            # difference at each cell then spans a range rather than a single
+            # value, evaluated with two extra global computations at t +/- dt
+            # rather than re-meshing the whole globe over many moments (issue #4).
+            r_minus = relative_difference_at(-seconds)
+            r_plus = relative_difference_at(seconds)
+            lower_difference = np.fmin(np.fmin(r_minus, location_likelihoods), r_plus)
+            upper_difference = np.fmax(np.fmax(r_minus, location_likelihoods), r_plus)
         else:
-            raise ValueError(
-                "Either object height and shadow length or sun altitude angle needs to be set."
-            )
+            lower_difference = location_likelihoods
+            upper_difference = location_likelihoods
 
-        if self.time_format == "utc":
-            self.location_likelihoods = location_likelihoods
-        elif self.time_format == "local":
-            self.location_likelihoods = np.full(np.shape(mask), np.nan)
-            np.place(
-                self.location_likelihoods,
-                mask,
-                location_likelihoods,
+        if self.time_uncertainty or measurement_sigma > 0:
+            # Widen the plausible range by the measurement band (issue #3), then
+            # measure how far a perfect match (0) sits outside that range. Cells
+            # whose range spans 0 are consistent with the observation (0 here).
+            lower_bound = lower_difference - measurement_sigma
+            upper_bound = upper_difference + measurement_sigma
+            gap = np.where(
+                lower_bound > 0,
+                lower_bound,
+                np.where(upper_bound < 0, -upper_bound, 0.0),
             )
+            # Keep cells where the sun is always below the horizon excluded.
+            gap = np.where(np.isnan(lower_bound), np.nan, gap)
+            location_uncertainty = self._reshape_to_grid(gap, mask)
 
-        self.location_likelihoods = np.reshape(
-            self.location_likelihoods, np.shape(self.lons), order="A"
-        )
+        self.location_likelihoods = self._reshape_to_grid(location_likelihoods, mask)
+        self.location_uncertainty = location_uncertainty
 
     def plot_shadows(
         self,
@@ -268,6 +349,15 @@ class ShadowFinder:
         cmap.set_over("white", alpha=0.5)  # Day time colour
         cmap.set_under("black", alpha=0.5)  # Night time colour
 
+        if self.location_uncertainty is not None:
+            # Uncertainties were provided: the surface is the distance from a
+            # perfect match to the observation's plausible range, so the bright
+            # region is exactly the area consistent with the observation.
+            surface = self.location_uncertainty
+        else:
+            # Default: distance of the relative-difference surface from a match.
+            surface = np.abs(self.location_likelihoods)
+
         norm = colors.BoundaryNorm(np.arange(0, 0.2, 0.02), cmap.N)
 
         # Create the map projection
@@ -279,7 +369,6 @@ class ShadowFinder:
         )
 
         # replace NaN values with a specific value (e.g. -1)
-        surface = np.abs(self.location_likelihoods)
         surface = np.where(np.isnan(surface), -1, surface)
 
         ax.pcolormesh(

--- a/src/shadowfinder/shadowfinder.py
+++ b/src/shadowfinder/shadowfinder.py
@@ -76,8 +76,8 @@ class ShadowFinder:
         self.date_time = date_time
 
         # Optional measurement/time uncertainties. When any are set, find_shadows
-        # propagates them into a per-cell uncertainty band (self.location_sigmas)
-        # instead of using the fixed default band width.
+        # propagates them into a per-cell consistency surface
+        # (self.location_uncertainty) instead of using the fixed default band.
         self.object_height_uncertainty = object_height_uncertainty
         self.shadow_length_uncertainty = shadow_length_uncertainty
         self.sun_altitude_angle_uncertainty = sun_altitude_angle_uncertainty
@@ -295,6 +295,11 @@ class ShadowFinder:
             # difference at each cell then spans a range rather than a single
             # value, evaluated with two extra global computations at t +/- dt
             # rather than re-meshing the whole globe over many moments (issue #4).
+            # The 3-sample min/max is an approximation: for a cell whose local
+            # solar noon falls inside the window the true extremum is interior,
+            # but there the shadow barely moves, so the bracket stays tight
+            # exactly where the candidate band is, and only under-covers on the
+            # fast-moving low-sun cells that are excluded regardless.
             r_minus = relative_difference_at(-seconds)
             r_plus = relative_difference_at(seconds)
             lower_difference = np.fmin(np.fmin(r_minus, location_likelihoods), r_plus)
@@ -307,8 +312,12 @@ class ShadowFinder:
             # Widen the plausible range by the measurement band (issue #3), then
             # measure how far a perfect match (0) sits outside that range. Cells
             # whose range spans 0 are consistent with the observation (0 here).
-            lower_bound = lower_difference - measurement_sigma
-            upper_bound = upper_difference + measurement_sigma
+            # The band on a relative difference r is (1 + r) * measurement_sigma:
+            # the measurement uncertainty scales with the predicted-to-observed
+            # ratio (1 + r), so the band is exact to first order everywhere, not
+            # just at the match. This applies identically in sun-altitude mode.
+            lower_bound = lower_difference - (1 + lower_difference) * measurement_sigma
+            upper_bound = upper_difference + (1 + upper_difference) * measurement_sigma
             gap = np.where(
                 lower_bound > 0,
                 lower_bound,

--- a/tests/test_shadowfinder.py
+++ b/tests/test_shadowfinder.py
@@ -63,9 +63,10 @@ def test_no_uncertainty_leaves_uncertainty_none():
 
 
 def test_measurement_uncertainty_matches_propagation():
-    """Measurement uncertainties widen the consistent region by the propagated
-    relative error sqrt((dh/h)^2 + (ds/s)^2): the consistency surface is the
-    distance of the relative difference beyond that band."""
+    """Measurement uncertainties widen the consistent region by the first-order
+    propagated error (1 + r) * sqrt((dh/h)^2 + (ds/s)^2), where r is the cell's
+    relative difference; the consistency surface is the distance of a perfect
+    match (0) beyond that band."""
     # GIVEN height 10 +/- 1 and shadow 5 +/- 0.5
     finder = _utc_finder(object_height_uncertainty=1, shadow_length_uncertainty=0.5)
 
@@ -76,7 +77,10 @@ def test_measurement_uncertainty_matches_propagation():
     sigma = np.sqrt((1 / 10) ** 2 + (0.5 / 5) ** 2)
     assert finder.location_uncertainty is not None
     finite = ~np.isnan(finder.location_likelihoods)
-    expected = np.maximum(np.abs(finder.location_likelihoods[finite]) - sigma, 0)
+    r = finder.location_likelihoods[finite]
+    lower = r - (1 + r) * sigma
+    upper = r + (1 + r) * sigma
+    expected = np.where(lower > 0, lower, np.where(upper < 0, -upper, 0.0))
     assert np.allclose(finder.location_uncertainty[finite], expected)
 
 

--- a/tests/test_shadowfinder.py
+++ b/tests/test_shadowfinder.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+import numpy as np
+
 from shadowfinder import ShadowFinder
 
 
@@ -37,3 +39,81 @@ def test_creation_with_valid_arguments_local_time_format_should_pass():
 def test_find_shadows_with_local_time_format():
     finder = _gen_simple_finder_local_time()
     finder.find_shadows()
+
+
+def _utc_finder(**kwargs):
+    return ShadowFinder(
+        object_height=10,
+        shadow_length=5,
+        date_time=datetime(2024, 1, 1, 12, 0, 0),
+        time_format="utc",
+        **kwargs,
+    )
+
+
+def test_no_uncertainty_leaves_uncertainty_none():
+    """Without any uncertainty inputs, the output is unchanged and no
+    consistency surface is produced."""
+    # GIVEN / WHEN
+    finder = _utc_finder()
+    finder.find_shadows()
+
+    # THEN
+    assert finder.location_uncertainty is None
+
+
+def test_measurement_uncertainty_matches_propagation():
+    """Measurement uncertainties widen the consistent region by the propagated
+    relative error sqrt((dh/h)^2 + (ds/s)^2): the consistency surface is the
+    distance of the relative difference beyond that band."""
+    # GIVEN height 10 +/- 1 and shadow 5 +/- 0.5
+    finder = _utc_finder(object_height_uncertainty=1, shadow_length_uncertainty=0.5)
+
+    # WHEN
+    finder.find_shadows()
+
+    # THEN
+    sigma = np.sqrt((1 / 10) ** 2 + (0.5 / 5) ** 2)
+    assert finder.location_uncertainty is not None
+    finite = ~np.isnan(finder.location_likelihoods)
+    expected = np.maximum(np.abs(finder.location_likelihoods[finite]) - sigma, 0)
+    assert np.allclose(finder.location_uncertainty[finite], expected)
+
+
+def test_time_uncertainty_widens_but_excludes_terminator():
+    """A time uncertainty widens the consistent region beyond the exact-match
+    band, but does not flood the terminator: cells whose predicted shadow is
+    always far from the observation stay strongly excluded."""
+    # GIVEN only a time uncertainty of 30 minutes
+    finder = _utc_finder(time_uncertainty=1800)
+
+    # WHEN
+    finder.find_shadows()
+
+    # THEN
+    assert finder.location_uncertainty is not None
+    consistent = finder.location_uncertainty == 0
+    exact_match = np.abs(finder.location_likelihoods) < 1e-6
+    daytime = ~np.isnan(finder.location_likelihoods)
+
+    # widens the consistent region beyond the near-exact matches ...
+    assert np.count_nonzero(consistent) > np.count_nonzero(exact_match)
+    # ... but nowhere near the whole daytime hemisphere (no terminator flooding)
+    assert np.count_nonzero(consistent) < 0.5 * np.count_nonzero(daytime)
+    # ... and some cells are strongly excluded (large distance, not collapsed to ~0)
+    assert np.nanmax(finder.location_uncertainty) > 1
+
+
+def test_larger_uncertainty_widens_consistent_region():
+    """A larger measurement uncertainty admits at least as many consistent
+    cells."""
+
+    def consistent_count(shadow_length_uncertainty):
+        finder = _utc_finder(
+            object_height_uncertainty=0.1,
+            shadow_length_uncertainty=shadow_length_uncertainty,
+        )
+        finder.find_shadows()
+        return int(np.count_nonzero(finder.location_uncertainty == 0))
+
+    assert consistent_count(1.0) >= consistent_count(0.1)


### PR DESCRIPTION
Closes #3. Closes #4.

Currently the width of the possible-location band is a fixed constant. This lets users supply the uncertainty on their measurements and on the observation time, so the band reflects the region actually consistent with the observation.

## Model

Both uncertainty sources feed one per-cell **consistency** surface: the distance from a perfect match (relative difference = 0) to the *range* of relative differences the observation could plausibly take. A value of 0 means the cell is consistent with the observation; that region is what gets highlighted.

- **Measurement uncertainty (#3):** `object_height_uncertainty` / `shadow_length_uncertainty` (or `sun_altitude_angle_uncertainty`) widen the plausible range. The band on a relative difference `r` is `(1 + r) * sqrt((dh/h)^2 + (ds/s)^2)` — the first-order propagated error, which scales with the predicted-to-observed ratio `(1 + r)`. This is exact to first order everywhere (not just at the match) and correctly asymmetric: a long shadow tolerates more absolute error than a short one. The radians conversion cancels for the sun-altitude form, so the same `(1 + r)` scaling applies there.
- **Time uncertainty (#4):** `time_uncertainty` sweeps the observation time by ±dt and evaluates the sun position at `t ± dt` — two extra global computations, following the approach suggested in the issue thread, rather than re-meshing the whole globe over many moments. The relative difference at each cell then spans a range instead of a single value. (The 3-sample min/max bracket is tight exactly where the candidate band is — near a cell's local solar noon the shadow barely moves — and only under-covers on fast-moving low-sun cells that are excluded regardless.)

### Why range containment rather than a 1-sigma divide

The obvious approach — normalise the residual by a 1-sigma band — breaks down near the day/night terminator, where the shadow length is astronomically sensitive to time (`1/tan(altitude) -> inf`). There the band blows up, and dividing by it makes those cells look like strong candidates. Modelling the plausible range and asking whether it contains a perfect match keeps those cells correctly excluded (their predicted shadow is always far from the observed one).

Verified on a worked example: with a 30-minute time uncertainty the consistent region stays centred on the true solution (median sun altitude 63.4° = `arctan(10/5)`) with **0%** of consistent cells near the terminator; and the measurement-only consistent region matches the analytic first-order bounds.

## Compatibility & tests

- Output is **unchanged** when no uncertainty is supplied (`location_uncertainty` stays `None`, same fixed band as before, base surface bit-identical).
- Adds `find` / `find_sun` CLI options and README docs.
- New tests cover the measurement case (exact first-order propagation), the time case (widens the region but excludes the terminator), and that a larger uncertainty admits at least as many consistent cells. Full suite passes; `black` clean.

## Note

This touches `find_shadows`/`cli.py`, so it may need a trivial rebase if #36 or #37 merge first — happy to do that.